### PR TITLE
Reviewers API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 
 # Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.7'
 
 # Use Unicorn as the app server
 # gem 'unicorn'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.3.8)
     arel (6.0.3)
+    bcrypt (3.1.10)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
@@ -227,6 +228,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   byebug
   coffee-rails (~> 4.1.0)
   dalli

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,0 +1,2 @@
+class Api::BaseController < ApplicationController
+end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,2 +1,21 @@
 class Api::BaseController < ApplicationController
+  before_action :authenticate_with_token!
+
+  protected
+
+  def authenticate_with_token!
+    auth_header = request.headers["Authorization"]
+    unless auth_header.present?
+      head :unauthorized
+      return
+    end
+
+    token_id, token = auth_header.split(":")
+
+    api_token = ApiToken.find_by(token_id: token_id)
+    unless api_token.present? && api_token.authenticate(token)
+      head :unauthorized
+      return
+    end
+  end
 end

--- a/app/controllers/api/reviewers_controller.rb
+++ b/app/controllers/api/reviewers_controller.rb
@@ -1,0 +1,25 @@
+class Api::ReviewersController < Api::BaseController
+  def show
+    @pr = PullRequest.find_by(repository: params[:repo], number: params[:pull_id])
+    if @pr.present?
+      render json: params[:status] == "completed" ? @pr.completed_reviews : @pr.pending_reviews
+    else
+      head :not_found
+    end
+  end
+
+  def add_reviewer
+    @pr = PullRequest.find_by(repository: params[:repo], number: params[:pull_id])
+    if @pr.present?
+      reviewers_to_add = JSON.load(request.body.read)
+      @pr.pending_reviews += reviewers_to_add
+      if @pr.save
+        render json: @pr.pending_reviews
+      else
+        head :unprocessable_entity
+      end
+    else
+      head :not_found
+    end
+  end
+end

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -1,0 +1,37 @@
+require 'securerandom'
+
+class ApiToken < ActiveRecord::Base
+  attr_reader :token
+
+  validates :token_id, uniqueness: true, presence: true
+
+  validate do |record|
+    record.errors.add(:token, :blank) unless record.token_digest.present?
+  end
+
+  def token=(unecrypted_token)
+    if unecrypted_token.nil?
+      self.token_digest = nil
+    else
+      @token = unecrypted_token
+      self.token_digest = BCrypt::Password.create(unecrypted_token)
+    end
+  end
+
+  def self.make!
+    new_token_id = SecureRandom.uuid
+    new_token = SecureRandom.hex
+
+    new_obj = self.new
+    new_obj.token_id = new_token_id
+    new_obj.token = new_token
+
+    new_obj.save!
+
+    new_obj
+  end
+
+  def authenticate(unecrypted_token)
+    BCrypt::Password.new(self.token_digest) == unecrypted_token && self
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,4 +56,18 @@ Rails.application.routes.draw do
 
   post "/webhooks/pull_request" => "webhooks#pull_request"
   post "/webhooks/issue_comment" => "webhooks#issue_comment"
+
+  scope module: 'api', as: 'api' do
+
+    scope "/repos/:repo", constraints: { repo: /\w+\/\w+/ } do
+      resources :pulls, constraints: { id: /\d+/ }, only: [:index, :show] do
+        resource :reviewers, only: [:show] do
+          collection do
+            post 'add', to: "reviewers#add_reviewer"
+          end
+        end
+      end
+    end
+
+  end
 end

--- a/db/migrate/20160408205143_create_api_tokens.rb
+++ b/db/migrate/20160408205143_create_api_tokens.rb
@@ -1,0 +1,12 @@
+class CreateApiTokens < ActiveRecord::Migration
+  def change
+    create_table :api_tokens do |t|
+      t.string :token_id
+      t.string :token_digest
+
+      t.timestamps null: false
+    end
+
+    add_index :api_tokens, :token_id, unique: true, using: :btree
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160406185636) do
+ActiveRecord::Schema.define(version: 20160408205143) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "api_tokens", force: :cascade do |t|
+    t.string   "token_id"
+    t.string   "token_digest"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+  end
+
+  add_index "api_tokens", ["token_id"], name: "index_api_tokens_on_token_id", unique: true, using: :btree
 
   create_table "pull_requests", force: :cascade do |t|
     t.string   "status"

--- a/spec/controllers/api/base_controller_spec.rb
+++ b/spec/controllers/api/base_controller_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Api::BaseController, type: :controller do
+  controller do
+    def index
+      head :ok
+      return
+    end
+  end
+
+  describe "authentication" do
+    context "when no header is present" do
+      it "returns 401 Unauthorized" do
+        get :index
+
+        expect(response.status).to be(401)
+      end
+    end
+
+    context "when a valid token and token_id are passed in" do
+      it "returns 200 OK" do
+        new_token = ApiToken.make!
+        token_id = new_token.token_id
+        token = new_token.token
+
+        request.env["HTTP_AUTHORIZATION"] = "#{token_id}:#{token}"
+        get :index
+
+        expect(response.status).to be(200)
+      end
+    end
+  end
+end

--- a/spec/models/api_token_spec.rb
+++ b/spec/models/api_token_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe ApiToken, type: :model do
+  it { is_expected.to validate_presence_of :token_id }
+  it { is_expected.to validate_uniqueness_of :token_id }
+
+  describe ".make!" do
+    it "returns the new token object" do
+      expect(ApiToken.make!).to be_a(ApiToken)
+    end
+
+    it "returns the unencrypted token inside the token object" do
+      new_token = ApiToken.make!
+      expect(BCrypt::Password.new(new_token.token_digest)).to eq(new_token.token)
+    end
+  end
+
+  describe "#authenticate" do
+    it "returns true when the token is correct" do
+      token = ApiToken.make!
+      token_id = token.token_id
+      unencrypted = token.token
+
+      expect(ApiToken.find_by(token_id: token_id).authenticate(unencrypted)).to be_truthy
+    end
+
+    it "returns false when the token is not correct" do
+      token = ApiToken.make!
+      token_id = token.token_id
+      unencrypted = "n0tc0rr3ct"
+
+      expect(ApiToken.find_by(token_id: token_id).authenticate(unencrypted)).to be_falsey
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -24,7 +24,7 @@ Dotenv.load
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migration and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
@@ -62,6 +62,7 @@ end
 
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
+  config.include ApiHelper, type: :request
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,6 +63,7 @@ end
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
   config.include ApiHelper, type: :request
+  config.include ApiHelper, type: :controller
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/requests/api/pulls_requests_spec.rb
+++ b/spec/requests/api/pulls_requests_spec.rb
@@ -1,11 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe "Pulls API" do
+  before do
+    new_token = ApiToken.make!
+    @token_id = new_token.token_id
+    @token = new_token.token
+  end
+
   let!(:pr) { create :pull_request, pending_reviews: %w(aergonaut BrentW), completed_reviews: %w(mrpasquini) }
 
   describe "GET /repos/:repo/pulls/:number/reviewers" do
     it "returns the list of pending reviewers" do
-      get "/repos/aergonaut/testrepo/pulls/#{pr.number}/reviewers"
+      get "/repos/aergonaut/testrepo/pulls/#{pr.number}/reviewers", nil, api_headers(@token_id, @token)
 
       expect(response.status).to be(200)
       expect(json_body).to be_a(Array)
@@ -13,13 +19,13 @@ RSpec.describe "Pulls API" do
     end
 
     it "returns the list of completed reviewers if the status parameter is completed" do
-      get "/repos/aergonaut/testrepo/pulls/#{pr.number}/reviewers?status=completed"
+      get "/repos/aergonaut/testrepo/pulls/#{pr.number}/reviewers?status=completed", nil, api_headers(@token_id, @token)
 
       expect(json_body).to contain_exactly("mrpasquini")
     end
 
     it "returns 404 for a PR that can't be found" do
-      get "/repos/octocat/spoonknife/pulls/#{pr.number}/reviewers"
+      get "/repos/octocat/spoonknife/pulls/#{pr.number}/reviewers", nil, api_headers(@token_id, @token)
 
       expect(response.status).to be(404)
     end
@@ -27,7 +33,7 @@ RSpec.describe "Pulls API" do
 
   describe "POST /repos/:repo/pulls/:number/reviewers/add" do
     it "adds the specified reviewers to the list of pending reviews" do
-      post "/repos/aergonaut/testrepo/pulls/#{pr.number}/reviewers/add", "[\"saghaulor\"]"
+      post "/repos/aergonaut/testrepo/pulls/#{pr.number}/reviewers/add", "[\"saghaulor\"]", api_headers(@token_id, @token)
 
       expect(response.status).to be(200)
       expect(pr.reload.pending_reviews).to contain_exactly("aergonaut", "BrentW", "saghaulor")

--- a/spec/requests/api/pulls_requests_spec.rb
+++ b/spec/requests/api/pulls_requests_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe "Pulls API" do
+  let!(:pr) { create :pull_request, pending_reviews: %w(aergonaut BrentW), completed_reviews: %w(mrpasquini) }
+
+  describe "GET /repos/:repo/pulls/:number/reviewers" do
+    it "returns the list of pending reviewers" do
+      get "/repos/aergonaut/testrepo/pulls/#{pr.number}/reviewers"
+
+      expect(response.status).to be(200)
+      expect(json_body).to be_a(Array)
+      expect(json_body).to contain_exactly("aergonaut", "BrentW")
+    end
+
+    it "returns the list of completed reviewers if the status parameter is completed" do
+      get "/repos/aergonaut/testrepo/pulls/#{pr.number}/reviewers?status=completed"
+
+      expect(json_body).to contain_exactly("mrpasquini")
+    end
+
+    it "returns 404 for a PR that can't be found" do
+      get "/repos/octocat/spoonknife/pulls/#{pr.number}/reviewers"
+
+      expect(response.status).to be(404)
+    end
+  end
+
+  describe "POST /repos/:repo/pulls/:number/reviewers/add" do
+    it "adds the specified reviewers to the list of pending reviews" do
+      post "/repos/aergonaut/testrepo/pulls/#{pr.number}/reviewers/add", "[\"saghaulor\"]"
+
+      expect(response.status).to be(200)
+      expect(pr.reload.pending_reviews).to contain_exactly("aergonaut", "BrentW", "saghaulor")
+    end
+  end
+end

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -2,4 +2,12 @@ module ApiHelper
   def json_body
     JSON.load(response.body)
   end
+
+  def api_headers(token_id, token)
+    {
+      "CONTENT_TYPE" => "application/json",
+      "ACCEPT" => "application/json",
+      "AUTHORIZATION" => "#{token_id}:#{token}"
+    }
+  end
 end

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -1,0 +1,5 @@
+module ApiHelper
+  def json_body
+    JSON.load(response.body)
+  end
+end


### PR DESCRIPTION
Adding minimal API for accessing and adding to the reviewers list for a PR. Resolves #28
### Endpoints included

GET /repos/:repo/pulls/:number/reviewers
- Returns a JSON Array of the pending reviewers.
- Include ?status=completed to get the list of completed reviews instead

POST /repos/:repo/pulls/:number/reviewers/add
- Include a JSON Array in the request body listing reviewers to be added to the pending reviewers list
### Authentication

Authentication is handled through API tokens which are encrypted with bcrypt and use a token ID to identify clients (like AWS access keys).

All API requests must be authenticated.

Requests should specify the token ID and the API token, concatenated with a ":" in between, in the Authorization header, e.g.

```
GET /repos/aergonaut/cody/pulls/34/reviewers
Accept: application/json
Authorization: 159eebbb-bc3c-4830-adaf-3c78b2279604:d493f15f457dfc2b3083398de816a277
```
### Media types

The API accepts requests in JSON and responds with JSON. You need to specify application/json in the Accept header of your request, and if you are sending a body, you must also specify application/json in the Content-Type header.
### API versioning

I'm leaving this as a not-doing for now since the API is so simple, but I intend to handle versioning with custom Media types (e.g. application/vnd.cody.v1+json). When versioning is added application/json will still be supported as a shortcut to the latest version of the API.

/cc @saghaulor
