### PR TITLE
Fix 'Deploy to Heroku' button

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
   "description": "A simple bot to manage code review through Pull Requests",
   "repository": "https://github.com/aergonaut/cody",
   "addons": [
-    "heroku-postgres:hobby-dev",
+    "heroku-postgresql:hobby-dev",
     "heroku-redis:hobby-dev"
   ],
   "scripts": {


### PR DESCRIPTION
With current configuration heroku can't proceed by adding non-existing add-on `heroku-postgres:hobby-dev`.
Now it's named `heroku-postgresql:hobby-dev`

Here is an actual error:
<img src="http://image.prntscr.com/image/a04cd752b58e4589bcf850dbbe3bc014.png" width="500">