### PR TITLE
Passing sender's login to Sidekiq

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,5 @@ env:
 branches:
   only:
   - master
+addons:
+  postgresql: "9.4"

--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
   gem 'pry-byebug'
+  gem 'pry-rails'
 
   gem 'rspec-rails'
 

--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,8 @@ gem 'font-awesome-sass'
 
 gem 'pundit'
 
+gem 'paper_trail'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,6 +178,8 @@ GEM
     pry-byebug (3.4.2)
       byebug (~> 9.0)
       pry (~> 0.10)
+    pry-rails (0.3.6)
+      pry (>= 0.10.4)
     puma (3.9.1)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
@@ -343,6 +345,7 @@ DEPENDENCIES
   paper_trail
   pg (~> 0.15)
   pry-byebug
+  pry-rails
   puma
   pundit
   rails (= 5.1.1)
@@ -368,4 +371,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.1
+   1.15.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,9 @@ GEM
     omniauth-oauth2 (1.4.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
+    paper_trail (7.1.0)
+      activerecord (>= 4.0, < 5.2)
+      request_store (~> 1.1)
     parallel (1.11.2)
     parser (2.4.0.0)
       ast (~> 2.2)
@@ -216,6 +219,7 @@ GEM
     rake (12.0.0)
     rdoc (4.3.0)
     redis (3.3.3)
+    request_store (1.3.2)
     rspec-core (3.6.0)
       rspec-support (~> 3.6.0)
     rspec-expectations (3.6.0)
@@ -336,6 +340,7 @@ DEPENDENCIES
   netrc
   octokit
   omniauth-github
+  paper_trail
   pg (~> 0.15)
   pry-byebug
   puma

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -30,9 +30,7 @@ class WebhooksController < ApplicationController
     end
 
     if body["action"] == "opened" || body["action"] == "synchronize"
-      ReceivePullRequestEvent.perform_async(
-        body.slice("action", "number", "pull_request", "repository")
-      )
+      ReceivePullRequestEvent.perform_async(body)
     end
 
     head :accepted

--- a/app/graphql/functions/hash_field.rb
+++ b/app/graphql/functions/hash_field.rb
@@ -1,0 +1,13 @@
+module Functions
+  class HashField < GraphQL::Function
+    attr_reader :type
+    def initialize(field, type)
+      @field = field
+      @type = type
+    end
+
+    def call(obj, _args, _ctx)
+      obj[@field]
+    end
+  end
+end

--- a/app/graphql/types/reviewer_type.rb
+++ b/app/graphql/types/reviewer_type.rb
@@ -15,4 +15,25 @@ Types::ReviewerType = GraphQL::ObjectType.define do
       reviewer.review_rule
     }
   end
+
+  VersionType = GraphQL::ObjectType.define do
+    name "ReviewerVersion"
+
+    field :login, function: Functions::HashField.new(
+      "login",
+      types[types.String]
+    )
+
+    field :status, function: Functions::HashField.new(
+      "status",
+      types[types.String]
+    )
+  end
+
+  field :versions do
+    type types[VersionType]
+    resolve -> (reviewer, args, ctx) {
+      reviewer.versions.map(&:changeset)
+    }
+  end
 end

--- a/app/mediators/receive_pull_request_event.rb
+++ b/app/mediators/receive_pull_request_event.rb
@@ -4,12 +4,12 @@ class ReceivePullRequestEvent
   def perform(payload)
     @payload = payload
 
-    # Raven.user_context(
-    #   username: @payload["sender"]["login"]
-    # )
-    # Raven.tags_context(
-    #   event: "pull_request"
-    # )
+    Raven.user_context(
+      username: @payload["sender"]["login"]
+    )
+    Raven.tags_context(
+      event: "pull_request"
+    )
 
     case @payload["action"]
     when "opened"

--- a/app/mediators/receive_pull_request_event.rb
+++ b/app/mediators/receive_pull_request_event.rb
@@ -8,14 +8,17 @@ class ReceivePullRequestEvent
       username: @payload["sender"]["login"]
     )
     Raven.tags_context(
-      event: "pull_request"
+      event: "pull_request",
+      repo: @payload["repository"]["full_name"]
     )
 
-    case @payload["action"]
-    when "opened"
-      self.on_opened
-    when "synchronize"
-      self.on_synchronize
+    PaperTrail.whodunnit(@payload["sender"]["login"]) do
+      case @payload["action"]
+      when "opened"
+        self.on_opened
+      when "synchronize"
+        self.on_synchronize
+      end
     end
   end
 

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,4 +1,3 @@
 class Current < ActiveSupport::CurrentAttributes
   attribute :user
-  attribute :user_login
 end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,3 +1,4 @@
 class Current < ActiveSupport::CurrentAttributes
   attribute :user
+  attribute :user_login
 end

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -16,6 +16,8 @@ class PullRequest < ApplicationRecord
   belongs_to :parent_pull_request, required: false, class_name: "PullRequest"
   has_many :reviewers
 
+  has_paper_trail
+
   REVIEW_LINK_REGEX = /(?:R|r)eview(?:ed)?\s+in\s+#(\d+)/
   REVIEWER_CHECKBOX_REGEX = /[*-] +\[([ x])\] +@([A-Za-z0-9_-]+)/
 

--- a/app/models/reviewer.rb
+++ b/app/models/reviewer.rb
@@ -11,6 +11,8 @@ class Reviewer < ApplicationRecord
   scope :pending_review, -> { where(status: STATUS_PENDING_APPROVAL) }
   scope :completed_review, -> { where(status: STATUS_APPROVED) }
 
+  has_paper_trail
+
   def addendum
     <<~EOF
       ### #{self.name_with_code}

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,0 +1,1 @@
+PaperTrail.config.track_associations = false

--- a/db/migrate/20170718064541_create_versions.rb
+++ b/db/migrate/20170718064541_create_versions.rb
@@ -1,0 +1,36 @@
+# This migration creates the `versions` table, the only schema PT requires.
+# All other migrations PT provides are optional.
+class CreateVersions < ActiveRecord::Migration[5.1]
+
+  # The largest text column available in all supported RDBMS is
+  # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
+  # so that MySQL will use `longtext` instead of `text`.  Otherwise,
+  # when serializing very large objects, `text` might not be big enough.
+  # TEXT_BYTES = 1_073_741_823
+
+  def change
+    create_table :versions do |t|
+      t.string   :item_type, {:null=>false}
+      t.integer  :item_id,   null: false
+      t.string   :event,     null: false
+      t.string   :whodunnit
+      t.jsonb    :object
+
+      # Known issue in MySQL: fractional second precision
+      # -------------------------------------------------
+      #
+      # MySQL timestamp columns do not support fractional seconds unless
+      # defined with "fractional seconds precision". MySQL users should manually
+      # add fractional seconds precision to this migration, specifically, to
+      # the `created_at` column.
+      # (https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html)
+      #
+      # MySQL users should also upgrade to rails 4.2, which is the first
+      # version of ActiveRecord with support for fractional seconds in MySQL.
+      # (https://github.com/rails/rails/pull/14359)
+      #
+      t.datetime :created_at
+    end
+    add_index :versions, %i(item_type item_id)
+  end
+end

--- a/db/migrate/20170718064542_add_object_changes_to_versions.rb
+++ b/db/migrate/20170718064542_add_object_changes_to_versions.rb
@@ -1,0 +1,12 @@
+# This migration adds the optional `object_changes` column, in which PaperTrail
+# will store the `changes` diff for each update event. See the readme for
+# details.
+class AddObjectChangesToVersions < ActiveRecord::Migration[5.1]
+  # The largest text column available in all supported RDBMS.
+  # See `create_versions.rb` for details.
+  # TEXT_BYTES = 1_073_741_823
+
+  def change
+    add_column :versions, :object_changes, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170620212229) do
+ActiveRecord::Schema.define(version: 20170718064542) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,6 +63,17 @@ ActiveRecord::Schema.define(version: 20170620212229) do
     t.string "uid"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "versions", force: :cascade do |t|
+    t.string "item_type", null: false
+    t.integer "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.jsonb "object"
+    t.datetime "created_at"
+    t.jsonb "object_changes"
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -154,6 +154,7 @@ type ReviewerEdge {
 
 type ReviewerVersion {
   login: [String]
+  status: [String]
 }
 
 type User implements Node {

--- a/schema.graphql
+++ b/schema.graphql
@@ -131,6 +131,7 @@ type Reviewer implements Node {
   # The Review Rule that added this Reviewer
   reviewRule: ReviewRule
   status: String!
+  versions: [ReviewerVersion]
 }
 
 # The connection type for Reviewer.
@@ -149,6 +150,10 @@ type ReviewerEdge {
 
   # The item at the end of the edge.
   node: Reviewer
+}
+
+type ReviewerVersion {
+  login: [String]
 }
 
 type User implements Node {


### PR DESCRIPTION
In the `pull_request` event handler, we were slicing the request payload to reduce the payload size. But this was making it so we couldn't access all of the keys in the payload which was starting to become hard. This removes the slicing so the whole payload goes to the handler.

Now with this we always know what user triggered the event and can mark that user as the whodunnit for PaperTrail, and also track that user as the current user in Sentry.

This also adds PaperTrail to start tracking versions.