### PR TITLE
add bootsnap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,3 +108,5 @@ end
 gem 'graphiql-rails', group: :development
 
 gem 'tzinfo-data'
+
+gem 'bootsnap', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,8 @@ GEM
       aws-sdk-core (= 2.10.117)
     aws-sigv4 (1.0.2)
     bindex (0.5.0)
+    bootsnap (1.1.8)
+      msgpack (~> 1.0)
     builder (3.2.3)
     bulma-rails (0.4.3)
       sass (~> 3.2)
@@ -337,6 +339,7 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk
+  bootsnap
   bulma-rails
   byebug
   coffee-rails (~> 4.2.0)

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,5 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+
+require 'bootsnap/setup'


### PR DESCRIPTION
Bootsnap is in Rails 5.2 by default, seems like a good time to give it a try