### PR TITLE
Accept an optional @ sign when specifying the user in a replace comment

### DIFF
--- a/app/mediators/receive_issue_comment_event.rb
+++ b/app/mediators/receive_issue_comment_event.rb
@@ -124,7 +124,7 @@ class ReceiveIssueCommentEvent
     return false unless comment =~ /^cody\s+r(eplace)?\s+(?<directives>.*)$/
 
     directives = $LAST_MATCH_INFO[:directives]
-    return false unless directives.match?(/([A-Za-z0-9_-]+)=([A-Za-z0-9_-]+)/)
+    return false unless directives.match?(/([A-Za-z0-9_-]+)=@?([A-Za-z0-9_-]+)/)
     directives
   end
 
@@ -139,7 +139,7 @@ class ReceiveIssueCommentEvent
     )
     return false unless pr.present?
 
-    directives.scan(/([A-Za-z0-9_-]+)=([A-Za-z0-9_-]+)/).each do |code, login|
+    directives.scan(/([A-Za-z0-9_-]+)=@?([A-Za-z0-9_-]+)/).each do |code, login|
       reviewer = pr.generated_reviewers
         .joins(:review_rule)
         .find_by(review_rules: { short_code: code })

--- a/spec/mediators/receive_issue_comment_event_spec.rb
+++ b/spec/mediators/receive_issue_comment_event_spec.rb
@@ -103,6 +103,16 @@ RSpec.describe ReceiveIssueCommentEvent do
         expect { job.perform(payload) }.to_not change { foo_reviewer.reload.login }
       end
     end
+    
+    context "when the reviewer is specified with an @ sign" do
+      let(:comment) { "cody replace foo=@BrentW" }
+      let(:acceptable_reviewer) { "BrentW" }
+      
+      it "replaces aergonaut with BrentW" do
+        foo_reviewer = pr.reviewers.find_by(review_rule_id: rule.id)
+        expect { job.perform(payload) }.to change { foo_reviewer.reload.login }.from("aergonaut").to("BrentW")
+      end
+    end
   end
   
   describe "#comment_replace_me" do


### PR DESCRIPTION
Allow @ sign in replace comments so we can use mention auto-complete.  

Might want to consolidate the regexes at some point.