### PR TITLE
Allow directly adding github username using autocomplete so you don't have to remember all the mentions

### DIFF
--- a/spec/mediators/receive_issue_comment_event_spec.rb
+++ b/spec/mediators/receive_issue_comment_event_spec.rb
@@ -129,6 +129,16 @@ RSpec.describe ReceiveIssueCommentEvent do
         expect { job.perform(payload) }.to change { foo_reviewer.reload.login }.from("aergonaut").to("BrentW")
       end
     end
+
+    context "when the reviewer is specified with a space and an @ sign" do
+      let(:comment) { "cody replace foo= @BrentW" }
+      let(:acceptable_reviewer) { "BrentW" }
+
+      it "replaces aergonaut with BrentW" do
+        foo_reviewer = pr.reviewers.find_by(review_rule_id: rule.id)
+        expect { job.perform(payload) }.to change { foo_reviewer.reload.login }.from("aergonaut").to("BrentW")
+      end
+    end
   end
 
   describe "#comment_replace_me" do
@@ -165,7 +175,5 @@ RSpec.describe ReceiveIssueCommentEvent do
         expect { job.perform(payload) }.to_not change { foo_reviewer.reload.login }
       end
     end
-
   end
-
 end


### PR DESCRIPTION
- [ ] @aergonaut 
- Allow replacing the reviewers using github autocomplete without having to go back and delete the space after the '='sign.
- ex. `cody replace second_level= @aergonaut ` here allowing a space after '=' triggers the mention autocomplete
- Old behaviors is unchanged, command should work with or without a space
 