### PR TITLE
update 'replace me' command to consider paused reviewers, so it does not automatically assign a paused user

### DIFF
--- a/app/mediators/receive_issue_comment_event.rb
+++ b/app/mediators/receive_issue_comment_event.rb
@@ -194,7 +194,7 @@ class ReceiveIssueCommentEvent
     return unless old_reviewers.present?
 
     old_reviewers.each do |reviewer|
-      pos_logins = reviewer.review_rule.possible_reviewers
+      pos_logins = reviewer.review_rule.filtered_reviewers(pr)
       new_usr = pos_logins.reject { |usr| usr.casecmp(commenter).zero? }.sample
       reviewer.update!(login: new_usr) if new_usr
     end


### PR DESCRIPTION
# Issue

The basic pull request reviewer choosing code filters out users who are paused, but the `cody replace me` command handler did not filter those, leading to a potential automatic assignment of users who had paused automatic assignments.

# Change

Updated `replace me` to use filtered_reviewers instead of possible_reviewers

# Testing Strategy

Added a unit test that verifies that if all possible reviewers are paused, then the reviewer is not changed. This is sort of a roundabout way of testing this issue, but because the choice of reviewers is randomized, a test for replacement could randomly succeed without this code change. I guess I could use dependency injection to control the random selection for testing? I'm open to ideas. :) 