### PR TITLE
Balancing the load between reviewers by averagin last 7 days of assig…

### DIFF
--- a/app/models/review_rule.rb
+++ b/app/models/review_rule.rb
@@ -124,13 +124,11 @@ class ReviewRule < ApplicationRecord
       User.paused_logins |
       extra_excludes
 
-    reviewer_list.choose_reviewer(
-      exclude_list: excludes
+    reviewer_list.choose_reviewer(pull_request, exclude_list: excludes
     ) ||
-      reviewer_list.choose_reviewer(
-        exclude_list: pull_request.pending_review_logins
+      reviewer_list.choose_reviewer(pull_request, exclude_list: pull_request.pending_review_logins
       ) ||
-      reviewer_list.choose_reviewer
+      reviewer_list.choose_reviewer(pull_request)
   end
 
   def self.apply(pr, pull_request_hash)

--- a/spec/models/reviewer_list_spec.rb
+++ b/spec/models/reviewer_list_spec.rb
@@ -3,17 +3,21 @@ require "rails_helper"
 
 RSpec.describe ReviewerList do
   describe "#choose_reviewer" do
+    before do
+      @pull_request_1 = FactoryBot.create :pull_request, status: "pending_review"
+    end
+
     it "does not pick users who are in the exclude_list" do
       exclude_list = ["aergonaut"]
       list = ReviewerList.new(reviewers: ["aergonaut", "robertmonahon"])
-      chosen_reviewer = list.choose_reviewer(exclude_list: exclude_list)
+      chosen_reviewer = list.choose_reviewer(@pull_request_1, exclude_list: exclude_list)
       expect(chosen_reviewer.login).to eq("robertmonahon")
     end
 
     it "returns nil when all users are excluded" do
       exclude_list = ["aergonaut", "robertmonahon"]
       list = ReviewerList.new(reviewers: ["aergonaut", "robertmonahon"])
-      chosen_reviewer = list.choose_reviewer(exclude_list: exclude_list)
+      chosen_reviewer = list.choose_reviewer(@pull_request_1, exclude_list: exclude_list)
       expect(chosen_reviewer).to be_nil
     end
 
@@ -25,8 +29,26 @@ RSpec.describe ReviewerList do
         ]
 
       list = ReviewerList.new(reviewers: reviewers)
-      chosen_reviewer = list.choose_reviewer(exclude_list: [])
+      chosen_reviewer = list.choose_reviewer(@pull_request_1, exclude_list: [])
       expect(chosen_reviewer.login).to eq("aergonaut")
+    end
+
+    context "load balancing while choosing the reviewer" do
+      before do
+        @repository = FactoryBot.create :repository
+        @pull_request_1 = FactoryBot.create :pull_request, status: "pending_review", repository: @repository, created_at: Time.now
+        @pull_request_2 = FactoryBot.create :pull_request, status: "pending_review", repository: @repository, created_at: Time.now
+        FactoryBot.create :reviewer, status: "pending_approval", pull_request: @pull_request_1, login: "aergonaut", created_at: Time.now
+        FactoryBot.create :reviewer, status: "pending_approval", pull_request: @pull_request_1, login: "robertmonahon", created_at: Time.now
+        FactoryBot.create :reviewer, status: "pending_approval", login: "xyz", created_at: 1.month.ago
+        @pull_request_1.reload
+      end
+
+      it "should load balance reviewers based on last 7 days assignment" do
+        list = ReviewerList.new(reviewers: ["aergonaut", "robertmonahon", "xyz"])
+        chosen_reviewer = list.choose_reviewer(@pull_request_2, exclude_list: [])
+        expect(chosen_reviewer.login).to eq("xyz")
+      end
     end
   end
 


### PR DESCRIPTION
…nments

Modified the choose_reviewer method to add pull_request in the method declaration and changed the logic to select the reviewer based on the its load from last 7 days. Added a provision to not overwhelm a new reviewer or a paused reviewer by not giving them two consecutive PRs to review.